### PR TITLE
Add null check on target object when comparing dictionary object keys

### DIFF
--- a/src/editor/MissingKeys.svelte
+++ b/src/editor/MissingKeys.svelte
@@ -14,7 +14,7 @@
     for (let [key, value] of Object.entries(source)) {
       const isObject = typeof value === 'object'
       if (isObject) missingKeys.push(...compareDictKeys(target[key], source[key], fullKey ? `${fullKey}.${key}` : key))
-      if (target[key] === undefined || target[key] === null) missingKeys.push(fullKey ? `${fullKey}.${key}` : key)
+      if (target && (target[key] === undefined || target[key] === null)) missingKeys.push(fullKey ? `${fullKey}.${key}` : key)
     }
     return missingKeys
   }


### PR DESCRIPTION
Prevents crash on some projects while looking for unused keys